### PR TITLE
Fix car_id/cars_id mismatch

### DIFF
--- a/db/migrate/20250121140102_create_cars.rb
+++ b/db/migrate/20250121140102_create_cars.rb
@@ -7,6 +7,7 @@ class CreateCars < ActiveRecord::Migration[7.1]
       t.string :model
       t.integer :price_per_hour
       t.references :user, null: false, foreign_key: true
+      t.references :car, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20250121140102_create_cars.rb
+++ b/db/migrate/20250121140102_create_cars.rb
@@ -7,7 +7,6 @@ class CreateCars < ActiveRecord::Migration[7.1]
       t.string :model
       t.integer :price_per_hour
       t.references :user, null: false, foreign_key: true
-      t.references :car, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20250122163618_rename_cars_id_to_car_id_in_bookings.rb
+++ b/db/migrate/20250122163618_rename_cars_id_to_car_id_in_bookings.rb
@@ -1,0 +1,7 @@
+class RenameCarsIdToCarIdInBookings < ActiveRecord::Migration[7.1]
+  def change
+    def change
+      rename_column :bookings, :cars_id, :car_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_21_141517) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_22_163618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,10 +19,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_141517) do
     t.string "start_date"
     t.string "end_date"
     t.bigint "user_id", null: false
-    t.bigint "car_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["car_id"], name: "index_bookings_on_car_id"
+    t.bigint "car_id"
+    t.index ["car_id"], name: "index_bookings_on_cars_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end
 
@@ -54,7 +54,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_141517) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "bookings", "cars"
   add_foreign_key "bookings", "users"
   add_foreign_key "cars", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,11 +59,15 @@ puts 'Created cars:'
 cars.each { |car| puts "- #{car.brand} #{car.model} at #{car.address}" }
 
 # Create Bookings
-puts "Creating Booking DB seed"
-Booking.create(confirmed_booking: false, start_date: "2025-01-10", end_date: "2025-01-20", user: User.first, car: Car.first)
-Booking.create(confirmed_booking: false, start_date: "2025-01-08", end_date: "2025-01-10", user: User.first, car: Car.last)
-Booking.create(confirmed_booking: false, start_date: "2024-12-15", end_date: "2024-12-16", user: User.first, car: Car.last)
-Booking.create(confirmed_booking: false, start_date: "2024-12-05", end_date: "2024-12-12", user: User.first, car: Car.first)
-Booking.create(confirmed_booking: false, start_date: "2024-11-21", end_date: "2024-11-24", user: User.last, car: Car.last)
+if User.first.nil? || Car.first.nil?
+  puts "Error: Missing User or Car to create Booking."
+else
+  puts "Creating Booking DB seed"
+  Booking.create(confirmed_booking: false, start_date: "2025-01-10", end_date: "2025-01-20", user: User.first, car: Car.first)
+  Booking.create(confirmed_booking: false, start_date: "2025-01-08", end_date: "2025-01-10", user: User.first, car: Car.last)
+  Booking.create(confirmed_booking: false, start_date: "2024-12-15", end_date: "2024-12-16", user: User.first, car: Car.last)
+  Booking.create(confirmed_booking: false, start_date: "2024-12-05", end_date: "2024-12-12", user: User.first, car: Car.first)
+  Booking.create(confirmed_booking: false, start_date: "2024-11-21", end_date: "2024-11-24", user: User.last, car: Car.last)
 
-puts "Seeding complete! Created #{User.count} users and #{Car.count} cars."
+  puts "Seeding complete! Created #{User.count} users and #{Car.count} cars."
+end


### PR DESCRIPTION
It was a problem with our database schema using cars_id instead of car_id in the relation between cars and bookings. Not quite sure how this happened, but this fixes it. May introduce other problems so do check it.

I also just added a puts for error catching in the seeding file